### PR TITLE
feat(data): 封装 MNISTDataset 并且下载 MNIST 数据集

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -74,25 +74,25 @@ MNIST-CNN/
   - [x] 编写 `README.md`（项目说明、安装、快速开始）
   - [x] 更新 `.gitignore`（checkpoints/, outputs/, datasets/, logs/）
 
-- [ ] **配置模块 `config/`**
-  - [ ] `paths.py` — 项目路径常量（基于 PROJECT_ROOT 推导）
-  - [ ] `default.py` — 所有超参数默认值（batch_size, lr, epochs, model 结构, 设备等）
-  - [ ] `settings.py` — 合并默认值 + 命令行参数覆盖（argparse）
-  - [ ] `__init__.py` — 统一导出
+- [x] **配置模块 `config/`**
+  - [x] `paths.py` — 项目路径常量（基于 PROJECT_ROOT 推导）
+  - [x] `default.py` — 所有超参数默认值（batch_size, lr, epochs, model 结构, 设备等）
+  - [x] `settings.py` — 合并默认值 + 命令行参数覆盖（argparse）
+  - [x] `__init__.py` — 统一导出
 
-- [ ] **主入口 `main.py`**
-  - [ ] 子命令分发：`train` / `eval` / `infer`
-  - [ ] 全局参数：`--config`、`--device`、`--seed`
-  - [ ] 各子命令独立参数解析与调度
+- [x] **主入口 `main.py`**
+  - [x] 子命令分发：`train` / `eval` / `infer`
+  - [x] 全局参数：`--config`、`--device`、`--seed`
+  - [x] 各子命令独立参数解析与调度
 
 ---
 
 ### 数据模块 `src/data/`
 
-- [ ] **数据集封装**
-  - [ ] `dataset.py` — `torch.utils.data.Dataset` 子类，封装 MNIST
-  - [ ] 支持自动下载到 `datasets/` 目录
-  - [ ] 返回 `(image, label)` 元组
+- [X] **数据集封装**
+  - [X] `dataset.py` — `torch.utils.data.Dataset` 子类，封装 MNIST
+  - [X] 支持自动下载到 `datasets/` 目录
+  - [X] 返回 `(image, label)` 元组
 
 - [ ] **预处理与数据增强**
   - [ ] `transform.py` — `ToTensor()` + `Normalize((0.1307,), (0.3081,))`

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -1,0 +1,72 @@
+"""
+src/data/dataset.py
+
+MNIST Dataset wrapper with auto-download
+
+Usage:
+    dataset = MNISTDataset(train=True, transform=myTransform)
+    image, label = dataset[0]
+
+"""
+
+from pathlib import Path
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch.utils.data import Dataset
+from torchvision.datasets import MNIST
+
+from config.paths import DATASETS_DIR
+
+
+class MNISTDataset(Dataset):
+    """
+    Thin wrapper around torchvision.datasets.MNIST with auto-download to datasets/
+
+    """
+
+    def __init__(
+        self,
+        train: bool = True,  # Whether to load the training set (True) or test set (False)
+        transform: Optional[
+            Callable
+        ] = None,  # Optional transform to apply to the images
+        download: bool = True,  # Whether to download the dataset if not found
+        root: Optional[
+            Path
+        ] = None,  # Optional root directory to store the dataset (defaults to DATASETS_DIR)
+    ) -> None:
+        """
+        Args:
+            train(bool): Whether to load the training set (True) or test set (False)
+            transform(Optional[Callable]): torchvision transform to apply to the images (e.g. ToTensor, Normalize)
+            download(bool): Whether to download the dataset if not found
+            root(Optional[Path]): Optional root directory to store the dataset (defaults to DATASETS_DIR)
+
+
+        """
+        super().__init__()
+        self.train = train
+        self.root = root or DATASETS_DIR
+        self.dataset = MNIST(
+            root=str(self.root),
+            train=self.train,
+            transform=transform,
+            download=download,
+        )
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def __getitem__(self, index: int) -> Tuple[torch.Tensor, int]:
+        image, label = self.dataset[index]
+        return image, label
+
+
+if __name__ == "__main__":
+    print("Downloading MNIST dataset...")
+    trainDs = MNISTDataset(train=True, download=True)
+    testDs = MNISTDataset(train=False, download=True)
+    print(f"Train set: {len(trainDs)} images")
+    print(f"Test set:  {len(testDs)} images")
+    print(f"Files saved to: {DATASETS_DIR}")


### PR DESCRIPTION
- 新增 src/data/dataset.py，基于 torchvision.datasets.MNIST 实现 MNISTDataset 包装类，继承 torch.utils.data.Dataset
- 支持自动下载至 DATASETS_DIR、可选自定义 root 目录、可插拔 transform，__getitem__ 返回 (image, label) 元组
- 更新 docs/TODO.md，将配置模块、主入口、数据集封装三块任务标记为已完成

close #4