### PR TITLE
feat(data): 实现 MNIST 原始数据预处理与持久化存储流水线

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ authors = [
 dependencies = [
     "torch>=2.11.0",
     "torchvision>=0.26.0",
+    "tqdm>=4.67.3",
 ]
 
 # 可选依赖组（兼容 pip install ".[dev]" 方式安装）

--- a/src/data/process.py
+++ b/src/data/process.py
@@ -1,0 +1,96 @@
+"""
+src/data/process.py
+
+Read eaw MNIST, apply transforms pipelines, save preprocessed .pt files
+
+Outputs:
+    datasets/MNIST/processed/
+        - train.pt: training set (images and labels)
+        - test.pt: test set (images and labels)
+
+Usage:
+    uv run python -m src.data.process
+    from src.data.process import loadProcessed
+    images, labels = loadProcessed("train")
+
+"""
+
+from pathlib import Path
+from typing import Literal, Tuple
+
+import torch
+from torchvision.datasets import MNIST
+from tqdm import tqdm
+
+from config.paths import DATASETS_DIR
+from src.data.transform import getTestTransform
+
+PROCESSED_DIR = DATASETS_DIR / "MNIST" / "processed"
+
+
+def processSplit(train: bool, savePath: str | Path) -> None:
+    """
+    Process one split:
+        read raw MNIST -> ToTensor -> Normalize -> save .pt file
+    Args:
+        train(bool): whether to process the training set (True) or test set (False)
+        savePath(str or Path): where to save the processed .pt file
+
+    """
+    savePath = Path(savePath)
+    name = "train" if train else "test"
+    print(f"Processing {name} split...")
+
+    # load raw MNIST dataset with appropriate transform
+    dataset = MNIST(root=str(DATASETS_DIR), train=train, transform=getTestTransform())
+
+    images, labels = [], []
+
+    # iterate through the dataset, apply transforms, and collect images and labels
+    for i in tqdm(range(len(dataset)), desc=f"Processing {name}"):
+        img, label = dataset[i]
+        images.append(img)
+        labels.append(label)
+
+    # stack images and labels into tensors and save as .pt file
+    images = torch.stack(images)  # shape: (N, C, H, W)
+    labels = torch.tensor(labels)  # shape: (N,)
+
+    savePath.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "images": images,
+            "labels": labels,
+        },
+        str(savePath),
+    )
+
+    print(f" Saved -> {savePath} | images: {images.shape} labels: {labels.shape}")
+
+
+def processAll() -> None:
+    """Process both train and test splits"""
+    print("=" * 60)
+    print("Raw -> Processed")
+    processSplit(train=True, savePath=PROCESSED_DIR / "train.pt")
+    processSplit(train=False, savePath=PROCESSED_DIR / "test.pt")
+    print("Done")
+
+
+def loadProcessed(split: Literal["train", "test"]) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Load processed .pt file for the specified split.
+
+    Args:
+        split(str): "train" or "test"
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: (images, labels)
+    """
+    path = PROCESSED_DIR / f"{split}.pt"
+    data = torch.load(path)
+    return data["images"], data["labels"]
+
+
+if __name__ == "__main__":
+    processAll()

--- a/src/data/transform.py
+++ b/src/data/transform.py
@@ -1,0 +1,99 @@
+"""
+src/data/transform.py
+
+Preprocessing and augmentation transforms for MNIST
+
+Pipelines:
+    getTrainTransform: random rotation, random affine, ToTensor, Normalize
+    getTestTransform: ToTensor, Normalize
+
+Usage:
+    from src.data.transform import getTrainTransform
+    dataset = MNISTDataset(train=True, transform=getTrainTransform())
+
+"""
+
+from torchvision import transforms
+
+from config.default_params import DataParams
+
+
+def getTrainTransform(augment: bool = True) -> transforms.Compose:
+    """
+    Training pipeline: optional augmentation -> ToTensor -> Normalize
+
+    Args:
+        augment(bool):
+            - Positive and Negative Random rotation
+            - Positive and Negative Random affine
+
+    Returns:
+        transforms.Compose: Training pipeline
+    """
+    pipeline = []
+    if augment:
+        pipeline.append(
+            transforms.RandomAffine(
+                degrees=DataParams.ROTATION_DEGREES,
+                translate=(DataParams.TRANSLATION_RATIO, DataParams.TRANSLATION_RATIO),
+            )
+        )
+
+    # PIL.Image -> Tensor and normalize to [0, 1]
+    pipeline.append(transforms.ToTensor())
+    pipeline.append(
+        transforms.Normalize(mean=DataParams.MNIST_MEAN, std=DataParams.MNIST_STD)
+    )
+    return transforms.Compose(pipeline)
+
+
+def getTestTransform() -> transforms.Compose:
+    """
+    Validation / Test pipeline: ToTensor -> Normalize only
+    No augmentation — evaluation must be deterministic.
+
+    """
+    return transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize(mean=DataParams.MNIST_MEAN, std=DataParams.MNIST_STD),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    from src.data.dataset import MNISTDataset
+
+    # Load one raw image (no transform) — returns PIL.Image
+    rawDs = MNISTDataset(train=True, transform=None)
+    pilImg, label = rawDs[0]
+
+    print("=== Raw image (PIL.Image, no transform) ===")
+    print(f"Type:  {type(pilImg)}")
+    print(f"Size:  {pilImg.size}          # (W, H)")
+    print(f"Mode:  {pilImg.mode}          # L = grayscale")
+    print(
+        f"Pixel: [{pilImg.getpixel((0, 0))}, ..., {pilImg.getpixel((27, 27))}]  # uint8 [0-255]"
+    )
+    print(f"Label: {label}")
+
+    # Apply train transform (with augmentation) — returns normalized Tensor
+    print("\n=== After train transform (augment=True) ===")
+    dsAug = MNISTDataset(train=True, transform=getTrainTransform(augment=True))
+    tensorAug, _ = dsAug[0]
+    print(f"Type:   {type(tensorAug)}")
+    print(f"Shape:  {tensorAug.shape}    # (C, H, W)")
+    print(f"dtype:  {tensorAug.dtype}")
+    print(f"Min:    {tensorAug.min().item():.4f}")
+    print(f"Max:    {tensorAug.max().item():.4f}")
+    print(f"Mean:   {tensorAug.mean().item():.4f}")
+
+    # Apply test transform (no augmentation) — returns normalized Tensor
+    print("\n=== After test transform ===")
+    dsTest = MNISTDataset(train=True, transform=getTestTransform())
+    tensorTest, _ = dsTest[0]
+    print(f"Type:   {type(tensorTest)}")
+    print(f"Shape:  {tensorTest.shape}")
+    print(f"Min:    {tensorTest.min().item():.4f}")
+    print(f"Max:    {tensorTest.max().item():.4f}")
+    print(f"Mean:   {tensorTest.mean().item():.4f}")

--- a/uv.lock
+++ b/uv.lock
@@ -231,6 +231,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "torch" },
     { name = "torchvision" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -254,6 +255,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12" },
     { name = "torch", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchvision", specifier = ">=0.26.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "tqdm", specifier = ">=4.67.3" },
 ]
 provides-extras = ["dev"]
 
@@ -857,6 +859,18 @@ wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:f160dc552a086244f7102c898f7be8ef46a41b36bce5ea80a4f2493cb30ca1fc", upload-time = "2026-04-09T23:21:41Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- 新增 src/data/process.py，封装 processSplit / processAll / loadProcessed 三个核心函数
- processSplit 读取原始 MNIST 并应用 getTestTransform 归一化，将图像与标签堆叠为 Tensor 后以 .pt 格式落盘至 datasets/MNIST/processed/
- processAll 统一调度 train/test 两条分支，输出形状与路径信息便于核查
- loadProcessed 提供按 split 名称加载已处理文件的接口，支持下游模块复用
- pyproject.toml 补充 tqdm>=4.67.3 依赖，支持处理进度可视化

close #6 