### PR TITLE
feat(loss): 新增交叉熵损失函数工厂，完善训练模块基础设施

### DIFF
--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -1,0 +1,3 @@
+from src.train.loss import createLossFunction
+
+__all__ = ["createLossFunction"]

--- a/src/train/loss.py
+++ b/src/train/loss.py
@@ -1,0 +1,26 @@
+"""
+src/train/loss.py
+
+Loss function wrapper for MNIST classification.
+
+Usage:
+    from src.train.loss import createLoss
+    criterion = createLossFunction()
+    loss = criterion(logits, labels)
+"""
+
+import torch.nn as nn
+
+
+def createLossFunction() -> nn.CrossEntropyLoss:
+    """
+    Create the loss function for multi-class classification.
+
+    CrossEntropyLoss combines log_softmax + NLLLoss in one operation.
+    It expects raw logits (not softmax probabilities) and integer labels.
+
+    Returns:
+        nn.CrossEntropyLoss with default reduction='mean'.
+    """
+    criterion = nn.CrossEntropyLoss()
+    return criterion


### PR DESCRIPTION
- 新增 src/train/loss.py，封装 createLossFunction 工厂函数，返回 nn.CrossEntropyLoss 实例
- CrossEntropyLoss 内部融合 log_softmax 与 NLLLoss，直接接收原始 logits 与整数标签，默认使用 mean 归约
- 更新 src/train/__init__.py，将 createLossFunction 纳入包级导出，统一训练模块对外接口

close #12 