### PR TITLE
 feat(cnnlib): 搭建 Phase 1 基础设施，引入双注册表驱动架构

### DIFF
--- a/cnnlib/data/loader.py
+++ b/cnnlib/data/loader.py
@@ -1,0 +1,149 @@
+"""
+DataLoader 工厂
+
+根据模型名和数据集名，自动加载数据并构建 train/val/test 三个 DataLoader。
+
+职责：
+    1. 查注册表拿到数据集元信息（供 torchvision 类选择）
+    2. 调 transform.build_transform 自动拼 transform
+    3. 切分 train/val，构建 DataLoader
+
+用法：
+    from cnnlib.data.loader import build_dataloaders
+
+    train_loader, val_loader, test_loader = build_dataloaders(
+        model_name="vgg16",
+        dataset_name="cifar10",
+        batch_size=64,
+        data_dir="datasets/",
+    )
+"""
+
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from torch.utils.data import DataLoader, random_split
+from torchvision import datasets
+
+from cnnlib.data.transform import build_transform
+
+# 数据集名称 → torchvision 类
+_TORCHVISION_CLASS = {
+    "mnist": datasets.MNIST,
+    "fashionmnist": datasets.FashionMNIST,
+    "kmnist": datasets.KMNIST,
+    "emnist": datasets.EMNIST,
+    "cifar10": datasets.CIFAR10,
+    "cifar100": datasets.CIFAR100,
+    "svhn": datasets.SVHN,
+    "stl10": datasets.STL10,
+    "caltech101": datasets.Caltech101,
+    "gtsrb": datasets.GTSRB,
+    "flowers102": datasets.Flowers102,
+}
+
+
+def build_dataloaders(
+    model_name: str,
+    dataset_name: str,
+    batch_size: int = 64,
+    val_split: float = 0.1,
+    num_workers: int = 4,
+    pin_memory: bool = True,
+    data_dir: str = "datasets/",
+    seed: int = 42,
+) -> Tuple[DataLoader, DataLoader, DataLoader]:
+    """
+    构建 train / val / test 三个 DataLoader
+
+    流程：
+        1. 拿到 torchvision 数据集类
+        2. 分别构建 train 和 test 的 transform（train 含增强）
+        3. 加载数据集
+        4. 从 train 中切出 val
+        5. 包成 DataLoader
+
+    Args:
+        model_name:   模型名称，如 "vgg16"
+        dataset_name: 数据集名称，如 "cifar10"
+        batch_size:   批次大小
+        val_split:    验证集比例（从 train 中切）
+        num_workers:  DataLoader 子进程数
+        pin_memory:   是否 pin 内存（GPU 训练建议开启）
+        data_dir:     数据存储根目录
+        seed:         随机种子（控制 train/val 切分一致性）
+
+    Returns:
+        (train_loader, val_loader, test_loader)
+    """
+    dataset_name = dataset_name.lower()
+    if dataset_name not in _TORCHVISION_CLASS:
+        available = ", ".join(_TORCHVISION_CLASS.keys())
+        raise KeyError(f"Unknown dataset: '{dataset_name}'. Available: {available}")
+
+    dataset_cls = _TORCHVISION_CLASS[dataset_name]
+    data_root = Path(data_dir)
+
+    # 构建 transform
+    train_transform = build_transform(model_name, dataset_name, augment=True)
+    eval_transform = build_transform(model_name, dataset_name, augment=False)
+
+    # 加载原始数据集
+    train_full = dataset_cls(
+        root=str(data_root), train=True, download=True, transform=train_transform
+    )
+    test_dataset = dataset_cls(
+        root=str(data_root), train=False, download=True, transform=eval_transform
+    )
+
+    # 切分 train / val
+    val_size = int(len(train_full) * val_split)
+    train_size = len(train_full) - val_size
+
+    generator = torch.Generator().manual_seed(seed)
+    train_dataset, val_dataset = random_split(
+        train_full, [train_size, val_size], generator=generator
+    )
+
+    # val 不能用增强 transform，覆盖
+    val_dataset.dataset.transform = eval_transform
+
+    # 构建 DataLoader
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
+    test_loader = DataLoader(
+        test_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
+
+    return train_loader, val_loader, test_loader
+
+
+if __name__ == "__main__":
+    train_loader, val_loader, test_loader = build_dataloaders(
+        model_name="lenet",
+        dataset_name="fashionmnist",
+        batch_size=64,
+    )
+    print(f"train: {len(train_loader.dataset):,} samples, {len(train_loader)} batches")
+    print(f"val:   {len(val_loader.dataset):,} samples, {len(val_loader)} batches")
+    print(f"test:  {len(test_loader.dataset):,} samples, {len(test_loader)} batches")
+
+    images, labels = next(iter(train_loader))
+    print(f"batch shape: {images.shape}")

--- a/cnnlib/data/loader.py
+++ b/cnnlib/data/loader.py
@@ -1,14 +1,14 @@
 """
 DataLoader 工厂
 
-根据模型名和数据集名，自动加载数据并构建 train/val/test 三个 DataLoader。
+根据模型名和数据集名,自动加载数据并构建 train/val/test 三个 DataLoader.
 
-职责：
-    1. 查注册表拿到数据集元信息（供 torchvision 类选择）
+职责:
+    1. 查注册表拿到数据集元信息(供 torchvision 类选择)
     2. 调 transform.build_transform 自动拼 transform
-    3. 切分 train/val，构建 DataLoader
+    3. 切分 train/val,构建 DataLoader
 
-用法：
+用法:
     from cnnlib.data.loader import build_dataloaders
 
     train_loader, val_loader, test_loader = build_dataloaders(
@@ -57,22 +57,22 @@ def build_dataloaders(
     """
     构建 train / val / test 三个 DataLoader
 
-    流程：
+    流程:
         1. 拿到 torchvision 数据集类
-        2. 分别构建 train 和 test 的 transform（train 含增强）
+        2. 分别构建 train 和 test 的 transform(train 含增强)
         3. 加载数据集
         4. 从 train 中切出 val
         5. 包成 DataLoader
 
     Args:
-        model_name:   模型名称，如 "vgg16"
-        dataset_name: 数据集名称，如 "cifar10"
+        model_name:   模型名称,如 "vgg16"
+        dataset_name: 数据集名称,如 "cifar10"
         batch_size:   批次大小
-        val_split:    验证集比例（从 train 中切）
+        val_split:    验证集比例(从 train 中切)
         num_workers:  DataLoader 子进程数
-        pin_memory:   是否 pin 内存（GPU 训练建议开启）
+        pin_memory:   是否 pin 内存(GPU 训练建议开启)
         data_dir:     数据存储根目录
-        seed:         随机种子（控制 train/val 切分一致性）
+        seed:         随机种子(控制 train/val 切分一致性)
 
     Returns:
         (train_loader, val_loader, test_loader)
@@ -106,7 +106,7 @@ def build_dataloaders(
         train_full, [train_size, val_size], generator=generator
     )
 
-    # val 不能用增强 transform，覆盖
+    # val 不能用增强 transform,覆盖
     val_dataset.dataset.transform = eval_transform
 
     # 构建 DataLoader

--- a/cnnlib/data/transform.py
+++ b/cnnlib/data/transform.py
@@ -1,0 +1,89 @@
+"""
+自适应 Transform 管线
+
+根据模型注册表和数据集注册表，自动拼出正确的预处理流程。
+
+流程：
+    原始图像 → ToTensor → [通道转换: 灰度→RGB] → Resize(模型尺寸) → Normalize(数据集统计量)
+
+用法：
+    from cnnlib.data.transform import build_transform
+
+    train_tf = build_transform("vgg16", "cifar10", augment=True)
+    test_tf  = build_transform("vgg16", "cifar10", augment=False)
+"""
+
+from torchvision import transforms
+
+from cnnlib.registry.datasets import get_dataset_info
+from cnnlib.registry.models import get_model_info
+
+
+def build_transform(
+    model_name: str,
+    dataset_name: str,
+    augment: bool = True,
+) -> transforms.Compose:
+    """
+    根据模型和数据集自动构建 transform
+
+    查询两张注册表：
+        - 模型注册表 → 目标 input_size, channels
+        - 数据集注册表 → 原始 mean, std
+
+    Args:
+        model_name:   模型名称，如 "vgg16", "lenet"
+        dataset_name: 数据集名称，如 "cifar10", "mnist"
+        augment:      训练模式 = True（含数据增强），推理/评估 = False
+
+    Returns:
+        torchvision.transforms.Compose 对象
+    """
+    model_info = get_model_info(model_name)
+    dataset_info = get_dataset_info(dataset_name)
+
+    target_size = model_info["input_size"]
+    target_channels = model_info["channels"]
+    dataset_channels = dataset_info["channels"]
+    mean = dataset_info["mean"]
+    std = dataset_info["std"]
+
+    ops = []
+
+    # 1. 转 Tensor
+    ops.append(transforms.ToTensor())
+
+    # 2. 通道转换：数据集是灰度，模型要 RGB → 将单通道复制为三通道
+    if dataset_channels == 1 and target_channels == 3:
+        ops.append(transforms.Lambda(lambda x: x.repeat(3, 1, 1)))
+
+    # 3. 尺寸适配
+    ops.append(transforms.Resize((target_size, target_size)))
+
+    # 4. 数据增强（仅训练模式）
+    if augment:
+        ops.append(transforms.RandomHorizontalFlip())
+        ops.append(transforms.RandomRotation(degrees=10))
+
+    # 5. 归一化
+    ops.append(transforms.Normalize(mean=mean, std=std))
+
+    return transforms.Compose(ops)
+
+
+if __name__ == "__main__":
+    # 灰度模型 + 灰度数据集（不发散）
+    tf = build_transform("lenet", "mnist")
+    print("lenet + mnist:", tf)
+
+    # RGB 模型 + RGB 数据集（不变）
+    tf = build_transform("vgg16", "cifar10")
+    print("vgg16 + cifar10:", tf)
+
+    # RGB 模型 + 灰度数据集（1→3 通道转换）
+    tf = build_transform("vgg16", "mnist")
+    print("vgg16 + mnist:", tf)
+
+    # 训练模式
+    tf = build_transform("vgg16", "cifar10", augment=True)
+    print("vgg16 + cifar10 (train):", tf)

--- a/cnnlib/models/__init__.py
+++ b/cnnlib/models/__init__.py
@@ -1,0 +1,1 @@
+# cnnlib.models

--- a/cnnlib/models/base.py
+++ b/cnnlib/models/base.py
@@ -1,0 +1,90 @@
+# cnnlib/models/base.py
+
+"""
+CNN 模型基类
+
+不强制子类的内部结构, 只提供通用工具：
+    - 自动推导 feature_dim(一次虚拟前传)
+    - 参数量统计
+    - 结构摘要打印
+
+子类自由选择写法：
+    - 简单模型：用 nn.Sequential 堆叠
+    - 复杂模型：手写 forward, 用到 ModuleList / ModuleDict 都行
+
+用法：
+    from cnnlib.models.base import BaseModel
+
+    class MyNet(BaseModel):
+        def __init__(self, num_classes=10):
+            super().__init__(input_size=32, in_channels=1, num_classes=num_classes)
+            self.conv = nn.Sequential(...)
+            self.fc = nn.Sequential(...)
+
+        def forward(self, x):
+            x = self.conv(x)
+            x = torch.flatten(x, 1)
+            x = self.fc(x)
+            return x
+"""
+
+import torch
+import torch.nn as nn
+
+
+class BaseModel(nn.Module):
+    """
+    CNN 模型基类
+
+    子类需要在 __init__ 中调用 super().__init__() 并传入三个参数：
+        input_size  — 输入图像尺寸(正方形边长), 如 32, 224
+        in_channels — 输入通道数, 1=灰度 3=RGB
+        num_classes — 分类类别数
+
+    基类提供：
+        self.input_size、self.in_channels、self.num_classes — 随处可用
+        infer_feature_dim(module) — 自动计算展平后维度
+        param_count() — 总参数量
+        summary() — 结构摘要
+    """
+
+    def __init__(self, input_size: int, in_channels: int, num_classes: int = 10):
+        super().__init__()
+        self.input_size = input_size
+        self.in_channels = in_channels
+        self.num_classes = num_classes
+        self._param_count = None
+
+    # 工具方法
+
+    def infer_feature_dim(self, module: nn.Module) -> int:
+        """
+        对 module 跑一次虚拟前传, 自动计算 flatten 后的维度
+
+        Args:
+            module: 特征提取部分(卷积层), 不包含 flatten
+
+        用法：
+            self.conv = nn.Sequential(...)
+            self.feature_dim = self.infer_feature_dim(self.conv)
+        """
+        dummy = torch.zeros(1, self.in_channels, self.input_size, self.input_size)
+        with torch.no_grad():
+            x = module(dummy)
+            return int(x.view(1, -1).size(1))
+
+    def param_count(self) -> int:
+        """返回模型总参数量"""
+        if self._param_count is None:
+            self._param_count = sum(p.numel() for p in self.parameters())
+        return self._param_count
+
+    def summary(self) -> str:
+        """返回模型结构摘要"""
+        return (
+            f"{self.__class__.__name__}(\n"
+            f"  input:  ({self.in_channels}, {self.input_size}, {self.input_size})\n"
+            f"  params: {self.param_count():,}\n"
+            f"  classes: {self.num_classes}\n"
+            ")"
+        )

--- a/cnnlib/models/blocks.py
+++ b/cnnlib/models/blocks.py
@@ -1,0 +1,230 @@
+"""
+公共构建块
+
+CNN 架构常用的可复用模块，每个模型按需取用：
+
+    conv_block     — Conv2d → BN → ReLU → [MaxPool2d]
+    linear_block   — Linear → BN → ReLU → [Dropout]
+    inception_block — Inception 多分支并行（GoogLeNet 用）
+    nin_block       — mlpconv: Conv → 1×1 Conv → 1×1 Conv（NiN 用）
+
+用法：
+    from cnnlib.models.blocks import conv_block, inception_block, nin_block
+"""
+
+import torch
+import torch.nn as nn
+
+# ═══════════════════════════════════════════════════════════════
+# 基础块：ConvBlock / LinearBlock
+# ═══════════════════════════════════════════════════════════════
+
+
+class conv_block(nn.Module):
+    """
+    Conv2d → BatchNorm2d → ReLU → [MaxPool2d]
+
+    参数:
+        in_channels:  输入通道数
+        out_channels: 输出通道数
+        kernel_size:  卷积核大小（默认 3）
+        pool:         是否追加 2×2 MaxPool（默认 True）
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        pool: bool = True,
+    ):
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels, out_channels, kernel_size, padding=kernel_size // 2
+        )
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.pool = nn.MaxPool2d(kernel_size=2, stride=2) if pool else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.relu(x)
+        if self.pool is not None:
+            x = self.pool(x)
+        return x
+
+
+class linear_block(nn.Module):
+    """
+    Linear → BatchNorm1d → ReLU → [Dropout]
+
+    参数:
+        in_features:  输入维度
+        out_features: 输出维度
+        dropout:      Dropout 概率（None = 不启用）
+    """
+
+    def __init__(
+        self, in_features: int, out_features: int, dropout: float | None = 0.5
+    ):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+        self.bn = nn.BatchNorm1d(out_features)
+        self.relu = nn.ReLU(inplace=True)
+        self.dropout = nn.Dropout(p=dropout) if dropout and dropout > 0 else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.linear(x)
+        x = self.bn(x)
+        x = self.relu(x)
+        if self.dropout is not None:
+            x = self.dropout(x)
+        return x
+
+
+# ═══════════════════════════════════════════════════════════════
+# Inception 模块（GoogLeNet）
+# ═══════════════════════════════════════════════════════════════
+
+
+class inception_block(nn.Module):
+    """
+    Inception 模块：四条分支并行，结果在通道维拼接
+
+    分支:
+        1×1 Conv
+        1×1 Conv → 3×3 Conv
+        1×1 Conv → 5×5 Conv
+        3×3 MaxPool → 1×1 Conv
+
+    参数:
+        in_channels:  输入通道数
+        c1:           分支 1 的输出通道数（1×1）
+        c2_reduce:    分支 2 的瓶颈通道数（1×1 降维）
+        c2:           分支 2 的输出通道数（3×3）
+        c3_reduce:    分支 3 的瓶颈通道数
+        c3:           分支 3 的输出通道数（5×5）
+        c4:           分支 4 的输出通道数（MaxPool + 1×1）
+
+    参考:
+        Szegedy et al., "Going Deeper with Convolutions", 2014
+        (Inception v1 / GoogLeNet)
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        c1: int,
+        c2_reduce: int,
+        c2: int,
+        c3_reduce: int,
+        c3: int,
+        c4: int,
+    ):
+        super().__init__()
+
+        # 分支 1: 1×1 Conv
+        self.branch1 = nn.Sequential(
+            nn.Conv2d(in_channels, c1, kernel_size=1),
+            nn.ReLU(inplace=True),
+        )
+
+        # 分支 2: 1×1 → 3×3
+        self.branch2 = nn.Sequential(
+            nn.Conv2d(in_channels, c2_reduce, kernel_size=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(c2_reduce, c2, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+        )
+
+        # 分支 3: 1×1 → 5×5
+        self.branch3 = nn.Sequential(
+            nn.Conv2d(in_channels, c3_reduce, kernel_size=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(c3_reduce, c3, kernel_size=5, padding=2),
+            nn.ReLU(inplace=True),
+        )
+
+        # 分支 4: 3×3 MaxPool → 1×1
+        self.branch4 = nn.Sequential(
+            nn.MaxPool2d(kernel_size=3, stride=1, padding=1),
+            nn.Conv2d(in_channels, c4, kernel_size=1),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b1 = self.branch1(x)
+        b2 = self.branch2(x)
+        b3 = self.branch3(x)
+        b4 = self.branch4(x)
+        return torch.cat([b1, b2, b3, b4], dim=1)
+
+
+# ═══════════════════════════════════════════════════════════════
+# NiN 模块（Network in Network）
+# ═══════════════════════════════════════════════════════════════
+
+
+class nin_block(nn.Module):
+    """
+    mlpconv 块：Conv → ReLU → 1×1 Conv → ReLU → 1×1 Conv → ReLU
+
+    用多层感知机替代单层卷积，增强局部感受野内的非线性表达能力。
+
+    1×1 卷积的作用：
+        - 等价于对每个像素位置做一次全连接变换
+        - 不改变空间尺寸，只改变通道数
+        - 参数量极少
+
+    参数:
+        in_channels:  输入通道数
+        out_channels: 输出通道数
+        kernel_size:  第一层卷积核大小（默认 5）
+        padding:      填充大小（默认 same）
+
+    参考:
+        Lin et al., "Network In Network", 2014
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int = 5):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size, padding=kernel_size // 2),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, kernel_size=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, kernel_size=1),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+# ═══════════════════════════════════════════════════════════════
+# 调试
+# ═══════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    # 基础块
+    conv = conv_block(1, 32)
+    lin = linear_block(3136, 128)
+    print(f"conv_block params:  {sum(p.numel() for p in conv.parameters()):,}")
+    print(f"linear_block params: {sum(p.numel() for p in lin.parameters()):,}")
+
+    # Inception
+    inc = inception_block(192, 64, 96, 128, 16, 32, 32)
+    x = torch.randn(2, 192, 28, 28)
+    y = inc(x)
+    print(
+        f"inception_block: {x.shape} -> {y.shape}, params: {sum(p.numel() for p in inc.parameters()):,}"
+    )
+
+    # NiN
+    nin = nin_block(3, 192)
+    x = torch.randn(2, 3, 32, 32)
+    y = nin(x)
+    print(
+        f"nin_block: {x.shape} -> {y.shape}, params: {sum(p.numel() for p in nin.parameters()):,}"
+    )

--- a/cnnlib/models/factory.py
+++ b/cnnlib/models/factory.py
@@ -1,0 +1,112 @@
+"""
+模型工厂
+
+根据名称创建模型实例，注册表的唯一消费方。
+
+职责：
+    1. 查注册表拿类引用和元信息
+    2. 拼出 BaseModel 需要的 input_size / in_channels / num_classes
+    3. 实例化并迁移到设备
+
+用法：
+    from cnnlib.models.factory import create_model
+
+    model = create_model("lenet", num_classes=10, device="cuda")
+    model = create_model("cnn", num_classes=10, conv_channels=[32, 64, 128])
+"""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from cnnlib.registry.models import get_model_info
+
+
+def _get_device(device: str = "auto") -> str:
+    """解析设备参数"""
+    if device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return device
+
+
+def create_model(
+    name: str, num_classes: int = 10, device: str = "auto", **kwargs
+) -> nn.Module:
+    """
+    根据模型名称创建实例
+
+    Args:
+        name:        模型名称，如 "lenet", "cnn"
+        num_classes: 输出类别数（从数据集注册表获取）
+        device:      "cpu", "cuda" 或 "auto"（自动检测）
+        **kwargs:    透传给模型构造函数的额外参数
+                     - cnn: conv_channels, dropout
+                     - alexnet: dropout
+                     - vgg: variant ("11"/"13"/"16"/"19"), dropout
+
+    Returns:
+        模型实例，已在目标设备上
+
+    示例:
+        # 基础用法
+        model = create_model("lenet", num_classes=10)
+
+        # 带设备
+        model = create_model("vgg16", num_classes=100, device="cuda")
+
+        # 带模型专属参数
+        model = create_model("cnn", num_classes=10, conv_channels=[32, 64, 128])
+    """
+    device = _get_device(device)
+    info = get_model_info(name)
+
+    # 注册表的 channels 映射为 BaseModel 的 in_channels
+    base_args: dict[str, Any] = {
+        "input_size": info["input_size"],
+        "in_channels": info["channels"],
+        "num_classes": num_classes,
+    }
+
+    # 合并基类参数和模型专属参数
+    model = info["class"](**base_args, **kwargs)
+    model = model.to(device)
+    return model
+
+
+def create_model_for_dataset(
+    model_name: str,
+    dataset_name: str,
+    device: str = "auto",
+    **kwargs,
+) -> nn.Module:
+    """
+    快捷方法：从数据集注册表自动取 num_classes 创建模型
+
+    Args:
+        model_name:   模型名称，如 "lenet"
+        dataset_name: 数据集名称，如 "cifar10"
+        device:       "cpu", "cuda" 或 "auto"
+        **kwargs:     透传给 create_model
+
+    示例:
+        model = create_model_for_dataset("vgg16", "cifar100", device="cuda")
+    """
+    from cnnlib.registry.datasets import get_dataset_info
+
+    dataset_info = get_dataset_info(dataset_name)
+    return create_model(
+        name=model_name,
+        num_classes=dataset_info["num_classes"],
+        device=device,
+        **kwargs,
+    )
+
+
+if __name__ == "__main__":
+    # 需要先注册模型才能测试
+    try:
+        model = create_model("lenet", num_classes=10)
+        print(model.summary())
+    except KeyError as e:
+        print(f"[skip] {e}")

--- a/cnnlib/registry/datasets.py
+++ b/cnnlib/registry/datasets.py
@@ -1,0 +1,150 @@
+# cnnlib/registry/datasets.py
+
+"""
+数据集注册表
+
+只做三件事：
+    1. 登记：每个数据集一行字典条目
+    2. 查询：列出所有数据集、获取单个数据集元信息
+    3. 告诉 transform 和 loader 该怎么处理数据
+
+用法：
+    from cnnlib.registry.datasets import list_datasets, get_dataset_info
+
+    info = get_dataset_info("cifar10")
+    # info["channels"] → 3
+    # info["num_classes"] → 10
+"""
+
+from typing import Any, Dict, List
+
+# 每个条目记录一个数据集的全部元信息，加一行即接入新数据集
+datasets: Dict[str, Dict[str, Any]] = {
+    # -- 灰度 28x28 --
+    "mnist": {
+        "channels": 1,
+        "num_classes": 10,
+        "image_size": 28,
+        "mean": (0.1307,),
+        "std": (0.3081,),
+        "description": "MNIST handwritten digits (10 classes)",
+    },
+    "fashionmnist": {
+        "channels": 1,
+        "num_classes": 10,
+        "image_size": 28,
+        "mean": (0.2860,),
+        "std": (0.3530,),
+        "description": "Fashion-MNIST clothing (10 classes)",
+    },
+    "emnist": {
+        "channels": 1,
+        "num_classes": 47,
+        "image_size": 28,
+        "mean": (0.1736,),
+        "std": (0.3317,),
+        "description": "EMNIST letters + digits (47 classes)",
+    },
+    # -- RGB 32x32 --
+    "cifar10": {
+        "channels": 3,
+        "num_classes": 10,
+        "image_size": 32,
+        "mean": (0.4914, 0.4822, 0.4465),
+        "std": (0.2470, 0.2435, 0.2616),
+        "description": "CIFAR-10 natural images (10 classes)",
+    },
+    "cifar100": {
+        "channels": 3,
+        "num_classes": 100,
+        "image_size": 32,
+        "mean": (0.5071, 0.4867, 0.4408),
+        "std": (0.2675, 0.2565, 0.2761),
+        "description": "CIFAR-100 natural images (100 classes)",
+    },
+    "svhn": {
+        "channels": 3,
+        "num_classes": 10,
+        "image_size": 32,
+        "mean": (0.4377, 0.4438, 0.4728),
+        "std": (0.1980, 0.2010, 0.1970),
+        "description": "SVHN street view house numbers (10 classes)",
+    },
+    # -- RGB 96x96 --
+    "stl10": {
+        "channels": 3,
+        "num_classes": 10,
+        "image_size": 96,
+        "mean": (0.4467, 0.4398, 0.4066),
+        "std": (0.2603, 0.2566, 0.2713),
+        "description": "STL-10 natural images (10 classes)",
+    },
+    # -- RGB 尺寸不固定 --
+    "caltech101": {
+        "channels": 3,
+        "num_classes": 101,
+        "image_size": None,
+        "mean": (0.485, 0.456, 0.406),
+        "std": (0.229, 0.224, 0.225),
+        "description": "Caltech-101 objects (101 classes)",
+    },
+    "gtsrb": {
+        "channels": 3,
+        "num_classes": 43,
+        "image_size": None,
+        "mean": (0.3403, 0.3121, 0.3214),
+        "std": (0.2724, 0.2608, 0.2669),
+        "description": "GTSRB traffic signs (43 classes)",
+    },
+    "flowers102": {
+        "channels": 3,
+        "num_classes": 102,
+        "image_size": None,
+        "mean": (0.485, 0.456, 0.406),
+        "std": (0.229, 0.224, 0.225),
+        "description": "Oxford Flowers-102 (102 classes)",
+    },
+}
+
+
+def list_datasets() -> List[str]:
+    """返回所有已注册数据集的名称列表"""
+    return list(datasets.keys())
+
+
+def get_dataset_info(name: str) -> Dict[str, Any]:
+    """
+    获取数据集元信息
+
+    Args:
+        name: 数据集名称（大小写不敏感），如 "cifar10", "mnist"
+
+    Returns:
+        {"channels": int, "num_classes": int, "image_size": int|None,
+         "mean": tuple, "std": tuple, "description": str}
+    """
+    key = name.lower()
+    if key not in datasets:
+        available = ", ".join(datasets.keys())
+        raise KeyError(f"Unknown dataset: '{name}'. Available: {available}")
+    return datasets[key]
+
+
+def print_datasets():
+    """打印所有已注册数据集（调试用）"""
+    print(f"{'Name':<14} {'Channels':<5} {'Classes':<8} {'Size':<10} {'Description'}")
+    print("-" * 70)
+    for name, info in datasets.items():
+        size_str = (
+            f"{info['image_size']}x{info['image_size']}"
+            if info["image_size"]
+            else "variable"
+        )
+        print(
+            f"  {name:<12} {info['channels']:<5} "
+            f"{info['num_classes']:<8} {size_str:<10} {info['description']}"
+        )
+
+
+if __name__ == "__main__":
+    print_datasets()

--- a/cnnlib/registry/models.py
+++ b/cnnlib/registry/models.py
@@ -1,52 +1,50 @@
+# cnnlib/registry/models.py
+
 """
 模型注册表
 
-1. 登记: 装饰器注册模型类 + 元信息
-2. 查询: 列出所有已经注册的模型, 获取单个模型的信息
-3. 创建: 根据名称实例化模型
+只做三件事：
+    1. 登记：装饰器注册模型类 + 元信息
+    2. 查询：列出所有已注册模型、获取单个模型信息
+    3. 创建：根据名称实例化模型
 
-用法:
-    from cnnlib.registry.models import registerModel, listModels, createModel
+用法：
+    from cnnlib.registry.models import register_model, list_models, create_model
 
-    @registerModel("lenet", inputSize=32, channels=1, description="LeNet-5 (1998)")
+    @register_model("lenet", input_size=32, channels=1, description="LeNet-5 (1998)")
     class LeNet(nn.Module):
         ...
 
-    # 列出所有模型
-    names = listModels()
-
-    # 创建模型
-    model = createModel("lenet", numClasses=10)
-
+    names = list_models()
+    model = create_model("lenet", num_classes=10)
 """
 
 from typing import Any, Dict, List, Type
 
 import torch.nn as nn
 
-# 全局注册表, key 为模型名称, value为 {class, input_size, channels, description}
-_REGISTRY: Dict[str, Dict[str, Any]] = {}
+# key=模型名称, value={class, input_size, channels, description}
+_registry: Dict[str, Dict[str, Any]] = {}
 
 
-def register_model(name: str, input_size: int, channels: int, description: str = ""):
+def register_model(
+    name: str,
+    input_size: int,
+    channels: int,
+    description: str = "",
+):
     """
     装饰器：将模型类注册到全局注册表
 
     Args:
         name:        模型简称，如 "lenet", "alexnet", "vgg16"
-        inputSize:   模型要求的输入尺寸（正方形），如 32, 224
+        input_size:  模型要求的输入尺寸（正方形），如 32, 224
         channels:    模型要求的输入通道数，1=灰度 3=RGB
-        description: 一行中文描述
-
-    示例:
-        @registerModel("lenet", inputSize=32, channels=1, description="LeNet-5 (1998)")
-        class LeNet(nn.Module):
-            ..
-
+        description: 一行描述
     """
 
     def wrapper(cls: Type[nn.Module]) -> Type[nn.Module]:
-        _REGISTRY[name] = {
+        _registry[name] = {
             "class": cls,
             "input_size": input_size,
             "channels": channels,
@@ -58,21 +56,21 @@ def register_model(name: str, input_size: int, channels: int, description: str =
 
 
 def list_models() -> List[str]:
-    """返回所有已经注册的模型的名称列表"""
-    return list(_REGISTRY)
+    """返回所有已注册模型的名称列表"""
+    return list(_registry.keys())
 
 
-def get_model_info(name: str) -> List[str]:
-    """获取模型的元信息(不实例化)
+def get_model_info(name: str) -> Dict[str, Any]:
+    """
+    获取模型元信息（不实例化）
 
     Returns:
-        {"class": cls, "inputSize": int, "channels": int, "description": str}
-
+        {"class": cls, "input_size": int, "channels": int, "description": str}
     """
-    if name not in _REGISTRY:
-        available = ",".join(_REGISTRY.keys()) or "(None)"
-        raise KeyError(f"Not Found :{name}, Available: {available}")
-    return _REGISTRY[name]
+    if name not in _registry:
+        available = ", ".join(_registry.keys()) or "(none)"
+        raise KeyError(f"Unknown model: '{name}'. Available: {available}")
+    return _registry[name]
 
 
 def create_model(name: str, num_classes: int = 10, **kwargs) -> nn.Module:
@@ -80,12 +78,18 @@ def create_model(name: str, num_classes: int = 10, **kwargs) -> nn.Module:
     根据名称创建模型实例
 
     Args:
-        name(str): 模型名称，如 "lenet"
+        name:        模型名称，如 "lenet"
         num_classes: 输出类别数
-        **kwargs: 传递给模型构造函数的额外参数
-
-    Returns:
-        nn.Module: 模型实例
+        **kwargs:    传递给模型构造函数的额外参数
     """
     info = get_model_info(name)
     return info["class"](num_classes=num_classes, **kwargs)
+
+
+def print_registry():
+    """打印所有已注册模型（调试用）"""
+    print(f"{'Name':<14} {'Input':<10} {'Ch':<5} {'Description'}")
+    print("-" * 60)
+    for name, info in _registry.items():
+        size = f"{info['input_size']}x{info['input_size']}"
+        print(f"  {name:<12} {size:<10} {info['channels']:<5} {info['description']}")

--- a/cnnlib/registry/models.py
+++ b/cnnlib/registry/models.py
@@ -1,0 +1,91 @@
+"""
+模型注册表
+
+1. 登记: 装饰器注册模型类 + 元信息
+2. 查询: 列出所有已经注册的模型, 获取单个模型的信息
+3. 创建: 根据名称实例化模型
+
+用法:
+    from cnnlib.registry.models import registerModel, listModels, createModel
+
+    @registerModel("lenet", inputSize=32, channels=1, description="LeNet-5 (1998)")
+    class LeNet(nn.Module):
+        ...
+
+    # 列出所有模型
+    names = listModels()
+
+    # 创建模型
+    model = createModel("lenet", numClasses=10)
+
+"""
+
+from typing import Any, Dict, List, Type
+
+import torch.nn as nn
+
+# 全局注册表, key 为模型名称, value为 {class, input_size, channels, description}
+_REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+
+def register_model(name: str, input_size: int, channels: int, description: str = ""):
+    """
+    装饰器：将模型类注册到全局注册表
+
+    Args:
+        name:        模型简称，如 "lenet", "alexnet", "vgg16"
+        inputSize:   模型要求的输入尺寸（正方形），如 32, 224
+        channels:    模型要求的输入通道数，1=灰度 3=RGB
+        description: 一行中文描述
+
+    示例:
+        @registerModel("lenet", inputSize=32, channels=1, description="LeNet-5 (1998)")
+        class LeNet(nn.Module):
+            ..
+
+    """
+
+    def wrapper(cls: Type[nn.Module]) -> Type[nn.Module]:
+        _REGISTRY[name] = {
+            "class": cls,
+            "input_size": input_size,
+            "channels": channels,
+            "description": description,
+        }
+        return cls
+
+    return wrapper
+
+
+def list_models() -> List[str]:
+    """返回所有已经注册的模型的名称列表"""
+    return list(_REGISTRY)
+
+
+def get_model_info(name: str) -> List[str]:
+    """获取模型的元信息(不实例化)
+
+    Returns:
+        {"class": cls, "inputSize": int, "channels": int, "description": str}
+
+    """
+    if name not in _REGISTRY:
+        available = ",".join(_REGISTRY.keys()) or "(None)"
+        raise KeyError(f"Not Found :{name}, Available: {available}")
+    return _REGISTRY[name]
+
+
+def create_model(name: str, num_classes: int = 10, **kwargs) -> nn.Module:
+    """
+    根据名称创建模型实例
+
+    Args:
+        name(str): 模型名称，如 "lenet"
+        num_classes: 输出类别数
+        **kwargs: 传递给模型构造函数的额外参数
+
+    Returns:
+        nn.Module: 模型实例
+    """
+    info = get_model_info(name)
+    return info["class"](num_classes=num_classes, **kwargs)

--- a/cnnlib/registry/models.py
+++ b/cnnlib/registry/models.py
@@ -3,20 +3,21 @@
 """
 模型注册表
 
-只做三件事：
+只做两件事：
     1. 登记：装饰器注册模型类 + 元信息
     2. 查询：列出所有已注册模型、获取单个模型信息
-    3. 创建：根据名称实例化模型
+
+创建实例走 cnnlib/models/factory.py
 
 用法：
-    from cnnlib.registry.models import register_model, list_models, create_model
+    from cnnlib.registry.models import register_model, list_models, get_model_info
 
     @register_model("lenet", input_size=32, channels=1, description="LeNet-5 (1998)")
     class LeNet(nn.Module):
         ...
 
     names = list_models()
-    model = create_model("lenet", num_classes=10)
+    info = get_model_info("lenet")
 """
 
 from typing import Any, Dict, List, Type
@@ -71,19 +72,6 @@ def get_model_info(name: str) -> Dict[str, Any]:
         available = ", ".join(_registry.keys()) or "(none)"
         raise KeyError(f"Unknown model: '{name}'. Available: {available}")
     return _registry[name]
-
-
-def create_model(name: str, num_classes: int = 10, **kwargs) -> nn.Module:
-    """
-    根据名称创建模型实例
-
-    Args:
-        name:        模型名称，如 "lenet"
-        num_classes: 输出类别数
-        **kwargs:    传递给模型构造函数的额外参数
-    """
-    info = get_model_info(name)
-    return info["class"](num_classes=num_classes, **kwargs)
 
 
 def print_registry():


### PR DESCRIPTION



## PR 描述

## 概述

本 PR 完成 ALL-CNN 项目 Phase 1 全部基础设施搭建（#17 Roadmap / Task #18）。
在 `cnnlib/` 下建立了模型与数据集完全解耦的模块化架构，核心设计思路是
**双注册表驱动 + 工厂模式**——模型和数据集互不知晓对方的存在，仅通过
注册表元信息在 transform 和 factory 层面自动适配。

## 架构总览

```
cnnlib/
├── registry/          # 两张独立注册表
│   ├── models.py      #   模型注册表：名称 → 类引用 + input_size + channels
│   └── datasets.py    #   数据集注册表：名称 → channels + num_classes + mean/std
├── models/            # 模型层
│   ├── base.py        #   BaseModel 基类（参数统计、特征维度推断）
│   ├── blocks.py      #   通用构建块（conv_block / linear_block / inception / nin）
│   └── factory.py     #   模型工厂（create_model / create_model_for_dataset）
└── data/              # 数据层
    ├── transform.py   #   自适应 transform 管线（查双注册表自动拼 Compose）
    └── loader.py      #   DataLoader 工厂（一键生成 train/val/test 三路数据流）
```

## 核心设计决策

- **注册表与工厂分离**：注册表只负责"知道有什么"，工厂负责"创建实例"
- **自适应 Transform**：从模型注册表取 target_size/channels，从数据集注册表取 mean/std，自动拼出正确的预处理管线（含灰度→RGB 通道转换、数据增强等）
- **BaseModel 基类**：`input_size` / `in_channels` / `num_classes` 作为构造参数传入，不设类属性，显式优于隐式
- **DataLoader 工厂**：自动处理 train/val 切分（固定种子）、val 覆盖 eval transform 等细节
- **通用构建块**：conv_block / linear_block / inception_block / nin_block 可直接复用，不在单个模型内重复造轮子

## 涉及文件（9 files, +904 lines）

| 文件 | 说明 |
|---|---|
| `cnnlib/registry/models.py` | 模型注册表 + @register_model 装饰器 |
| `cnnlib/registry/datasets.py` | 11 个数据集注册表 |
| `cnnlib/models/base.py` | BaseModel 基类 |
| `cnnlib/models/blocks.py` | conv_block / linear_block / inception_block / nin_block |
| `cnnlib/models/factory.py` | create_model / create_model_for_dataset |
| `cnnlib/models/__init__.py` | 子包初始化 |
| `cnnlib/data/transform.py` | build_transform 自适应管线 |
| `cnnlib/data/loader.py` | build_dataloaders 工厂 |
| `cnnlib/__init__.py` | 顶层包标记 |

## 提交记录

1. `deffc33` — 创建 cnnlib 文件夹
2. `130d70e` — 模型注册表模块
3. `652c2c2` — 数据集注册表（11 个数据集）
4. `7a4a345` — 初始化 models 子包
5. `f2f1494` — 模型工厂模块
6. `ebe8d1c` — CNN 通用构建块（含 Inception、NiN）
7. `613e9b9` — 自适应 transform 管线
8. `02dc0ac` — DataLoader 工厂
9. `f7d6266` — 统一注释标点为中文全角

## 关联 Issue

- close #18
- close #20
- close #22
- close #23
- close #24
- close #25
- close #26
- close #27 
- ref #17