### PR TITLE
feat(models/lenet): 新增 LeNet-5 模型实现并完善模型包导出

### DIFF
--- a/cnnlib/models/__init__.py
+++ b/cnnlib/models/__init__.py
@@ -1,1 +1,9 @@
-# cnnlib.models
+"""
+cnnlib.models
+
+"""
+
+from cnnlib.models.blocks import conv_block, inception_block, linear_block, nin_block
+from cnnlib.models.lenet import LeNet
+
+__all__ = ["conv_block", "linear_block", "inception_block", "nin_block", "LeNet"]

--- a/cnnlib/models/blocks.py
+++ b/cnnlib/models/blocks.py
@@ -1,14 +1,14 @@
 """
 公共构建块
 
-CNN 架构常用的可复用模块，每个模型按需取用：
+CNN 架构常用的可复用模块,每个模型按需取用:
 
     conv_block     — Conv2d → BN → ReLU → [MaxPool2d]
     linear_block   — Linear → BN → ReLU → [Dropout]
-    inception_block — Inception 多分支并行（GoogLeNet 用）
-    nin_block       — mlpconv: Conv → 1×1 Conv → 1×1 Conv（NiN 用）
+    inception_block — Inception 多分支并行(GoogLeNet 用)
+    nin_block       — mlpconv: Conv → 1x1 Conv → 1x1 Conv(NiN 用)
 
-用法：
+用法:
     from cnnlib.models.blocks import conv_block, inception_block, nin_block
 """
 
@@ -16,7 +16,7 @@ import torch
 import torch.nn as nn
 
 # ═══════════════════════════════════════════════════════════════
-# 基础块：ConvBlock / LinearBlock
+# 基础块:ConvBlock / LinearBlock
 # ═══════════════════════════════════════════════════════════════
 
 
@@ -27,8 +27,8 @@ class conv_block(nn.Module):
     参数:
         in_channels:  输入通道数
         out_channels: 输出通道数
-        kernel_size:  卷积核大小（默认 3）
-        pool:         是否追加 2×2 MaxPool（默认 True）
+        kernel_size:  卷积核大小(默认 3)
+        pool:         是否追加 2x2 MaxPool(默认 True)
     """
 
     def __init__(
@@ -62,7 +62,7 @@ class linear_block(nn.Module):
     参数:
         in_features:  输入维度
         out_features: 输出维度
-        dropout:      Dropout 概率（None = 不启用）
+        dropout:      Dropout 概率(None = 不启用)
     """
 
     def __init__(
@@ -84,28 +84,28 @@ class linear_block(nn.Module):
 
 
 # ═══════════════════════════════════════════════════════════════
-# Inception 模块（GoogLeNet）
+# Inception 模块(GoogLeNet)
 # ═══════════════════════════════════════════════════════════════
 
 
 class inception_block(nn.Module):
     """
-    Inception 模块：四条分支并行，结果在通道维拼接
+    Inception 模块:四条分支并行,结果在通道维拼接
 
     分支:
-        1×1 Conv
-        1×1 Conv → 3×3 Conv
-        1×1 Conv → 5×5 Conv
-        3×3 MaxPool → 1×1 Conv
+        1x1 Conv
+        1x1 Conv → 3x3 Conv
+        1x1 Conv → 5x5 Conv
+        3x3 MaxPool → 1x1 Conv
 
     参数:
         in_channels:  输入通道数
-        c1:           分支 1 的输出通道数（1×1）
-        c2_reduce:    分支 2 的瓶颈通道数（1×1 降维）
-        c2:           分支 2 的输出通道数（3×3）
+        c1:           分支 1 的输出通道数(1x1)
+        c2_reduce:    分支 2 的瓶颈通道数(1x1 降维)
+        c2:           分支 2 的输出通道数(3x3)
         c3_reduce:    分支 3 的瓶颈通道数
-        c3:           分支 3 的输出通道数（5×5）
-        c4:           分支 4 的输出通道数（MaxPool + 1×1）
+        c3:           分支 3 的输出通道数(5x5)
+        c4:           分支 4 的输出通道数(MaxPool + 1x1)
 
     参考:
         Szegedy et al., "Going Deeper with Convolutions", 2014
@@ -124,13 +124,13 @@ class inception_block(nn.Module):
     ):
         super().__init__()
 
-        # 分支 1: 1×1 Conv
+        # 分支 1: 1x1 Conv
         self.branch1 = nn.Sequential(
             nn.Conv2d(in_channels, c1, kernel_size=1),
             nn.ReLU(inplace=True),
         )
 
-        # 分支 2: 1×1 → 3×3
+        # 分支 2: 1x1 → 3x3
         self.branch2 = nn.Sequential(
             nn.Conv2d(in_channels, c2_reduce, kernel_size=1),
             nn.ReLU(inplace=True),
@@ -138,7 +138,7 @@ class inception_block(nn.Module):
             nn.ReLU(inplace=True),
         )
 
-        # 分支 3: 1×1 → 5×5
+        # 分支 3: 1x1 → 5x5
         self.branch3 = nn.Sequential(
             nn.Conv2d(in_channels, c3_reduce, kernel_size=1),
             nn.ReLU(inplace=True),
@@ -146,7 +146,7 @@ class inception_block(nn.Module):
             nn.ReLU(inplace=True),
         )
 
-        # 分支 4: 3×3 MaxPool → 1×1
+        # 分支 4: 3x3 MaxPool → 1x1
         self.branch4 = nn.Sequential(
             nn.MaxPool2d(kernel_size=3, stride=1, padding=1),
             nn.Conv2d(in_channels, c4, kernel_size=1),
@@ -162,26 +162,26 @@ class inception_block(nn.Module):
 
 
 # ═══════════════════════════════════════════════════════════════
-# NiN 模块（Network in Network）
+# NiN 模块(Network in Network)
 # ═══════════════════════════════════════════════════════════════
 
 
 class nin_block(nn.Module):
     """
-    mlpconv 块：Conv → ReLU → 1×1 Conv → ReLU → 1×1 Conv → ReLU
+    mlpconv 块:Conv → ReLU → 1x1 Conv → ReLU → 1x1 Conv → ReLU
 
-    用多层感知机替代单层卷积，增强局部感受野内的非线性表达能力。
+    用多层感知机替代单层卷积,增强局部感受野内的非线性表达能力.
 
-    1×1 卷积的作用：
+    1x1 卷积的作用:
         - 等价于对每个像素位置做一次全连接变换
-        - 不改变空间尺寸，只改变通道数
+        - 不改变空间尺寸,只改变通道数
         - 参数量极少
 
     参数:
         in_channels:  输入通道数
         out_channels: 输出通道数
-        kernel_size:  第一层卷积核大小（默认 5）
-        padding:      填充大小（默认 same）
+        kernel_size:  第一层卷积核大小(默认 5)
+        padding:      填充大小(默认 same)
 
     参考:
         Lin et al., "Network In Network", 2014

--- a/cnnlib/models/blocks.py
+++ b/cnnlib/models/blocks.py
@@ -1,14 +1,14 @@
 """
 公共构建块
 
-CNN 架构常用的可复用模块，每个模型按需取用：
+CNN 架构常用的可复用模块,每个模型按需取用:
 
     conv_block     — Conv2d → BN → ReLU → [MaxPool2d]
     linear_block   — Linear → BN → ReLU → [Dropout]
-    inception_block — Inception 多分支并行（GoogLeNet 用）
-    nin_block       — mlpconv: Conv → 1x1 Conv → 1x1 Conv（NiN 用）
+    inception_block — Inception 多分支并行(GoogLeNet 用)
+    nin_block       — mlpconv: Conv → 1x1 Conv → 1x1 Conv(NiN 用)
 
-用法：
+用法:
     from cnnlib.models.blocks import conv_block, inception_block, nin_block
 """
 
@@ -16,7 +16,7 @@ import torch
 import torch.nn as nn
 
 # ═══════════════════════════════════════════════════════════════
-# 基础块：ConvBlock / LinearBlock
+# 基础块:ConvBlock / LinearBlock
 # ═══════════════════════════════════════════════════════════════
 
 
@@ -27,8 +27,8 @@ class conv_block(nn.Module):
     参数:
         in_channels:  输入通道数
         out_channels: 输出通道数
-        kernel_size:  卷积核大小（默认 3）
-        pool:         是否追加 2x2 MaxPool（默认 True）
+        kernel_size:  卷积核大小(默认 3)
+        pool:         是否追加 2x2 MaxPool(默认 True)
     """
 
     def __init__(
@@ -62,7 +62,7 @@ class linear_block(nn.Module):
     参数:
         in_features:  输入维度
         out_features: 输出维度
-        dropout:      Dropout 概率（None = 不启用）
+        dropout:      Dropout 概率(None = 不启用)
     """
 
     def __init__(
@@ -84,13 +84,13 @@ class linear_block(nn.Module):
 
 
 # ═══════════════════════════════════════════════════════════════
-# Inception 模块（GoogLeNet）
+# Inception 模块(GoogLeNet)
 # ═══════════════════════════════════════════════════════════════
 
 
 class inception_block(nn.Module):
     """
-    Inception 模块：四条分支并行，结果在通道维拼接
+    Inception 模块:四条分支并行,结果在通道维拼接
 
     分支:
         1x1 Conv
@@ -100,12 +100,12 @@ class inception_block(nn.Module):
 
     参数:
         in_channels:  输入通道数
-        c1:           分支 1 的输出通道数（1x1）
-        c2_reduce:    分支 2 的瓶颈通道数（1x1 降维）
-        c2:           分支 2 的输出通道数（3x3）
+        c1:           分支 1 的输出通道数(1x1)
+        c2_reduce:    分支 2 的瓶颈通道数(1x1 降维)
+        c2:           分支 2 的输出通道数(3x3)
         c3_reduce:    分支 3 的瓶颈通道数
-        c3:           分支 3 的输出通道数（5x5）
-        c4:           分支 4 的输出通道数（MaxPool + 1x1）
+        c3:           分支 3 的输出通道数(5x5)
+        c4:           分支 4 的输出通道数(MaxPool + 1x1)
 
     参考:
         Szegedy et al., "Going Deeper with Convolutions", 2014
@@ -162,26 +162,26 @@ class inception_block(nn.Module):
 
 
 # ═══════════════════════════════════════════════════════════════
-# NiN 模块（Network in Network）
+# NiN 模块(Network in Network)
 # ═══════════════════════════════════════════════════════════════
 
 
 class nin_block(nn.Module):
     """
-    mlpconv 块：Conv → ReLU → 1x1 Conv → ReLU → 1x1 Conv → ReLU
+    mlpconv 块:Conv → ReLU → 1x1 Conv → ReLU → 1x1 Conv → ReLU
 
-    用多层感知机替代单层卷积，增强局部感受野内的非线性表达能力。
+    用多层感知机替代单层卷积,增强局部感受野内的非线性表达能力.
 
-    1x1 卷积的作用：
+    1x1 卷积的作用:
         - 等价于对每个像素位置做一次全连接变换
-        - 不改变空间尺寸，只改变通道数
+        - 不改变空间尺寸,只改变通道数
         - 参数量极少
 
     参数:
         in_channels:  输入通道数
         out_channels: 输出通道数
-        kernel_size:  第一层卷积核大小（默认 5）
-        padding:      填充大小（默认 same）
+        kernel_size:  第一层卷积核大小(默认 5)
+        padding:      填充大小(默认 same)
 
     参考:
         Lin et al., "Network In Network", 2014

--- a/cnnlib/models/lenet.py
+++ b/cnnlib/models/lenet.py
@@ -1,0 +1,102 @@
+"""
+LeNet-5 经典卷积神经网络
+
+Y. LeCun et al., "Gradient-Based Learning Applied to Document Recognition", 1998.
+
+架构:
+    Input (1, 32, 32)
+      → Conv2d(1→6, 5×5) + Tanh     → (6, 28, 28)
+      → AvgPool2d(2×2, stride=2)     → (6, 14, 14)
+      → Conv2d(6→16, 5×5) + Tanh    → (16, 10, 10)
+      → AvgPool2d(2×2, stride=2)     → (16, 5, 5)
+      → Conv2d(16→120, 5×5) + Tanh  → (120, 1, 1)
+      → Flatten                       → (120)
+      → Linear(120→84) + Tanh        → (84)
+      → Linear(84→num_classes)        → (num_classes)
+
+特点:
+    - Tanh 激活函数（原始 LeNet 风格）
+    - Average Pooling（非 Max Pooling）
+    - Xavier 权重初始化
+"""
+
+import torch
+import torch.nn as nn
+
+from cnnlib.models.base import BaseModel
+from cnnlib.registry.models import register_model
+
+
+@register_model("lenet", input_size=32, channels=1, description="LeNet-5 (1998)")
+class LeNet(BaseModel):
+    """
+    LeNet-5 经典卷积神经网络
+
+    Y. LeCun et al., "Gradient-Based Learning Applied to Document Recognition", 1998.
+
+    架构:
+        Input (1, 32, 32)
+          → Conv2d(1→6, 5×5) + Tanh     → (6, 28, 28)
+          → AvgPool2d(2×2, stride=2)     → (6, 14, 14)
+          → Conv2d(6→16, 5×5) + Tanh    → (16, 10, 10)
+          → AvgPool2d(2×2, stride=2)     → (16, 5, 5)
+          → Conv2d(16→120, 5×5) + Tanh  → (120, 1, 1)
+          → Flatten                       → (120)
+          → Linear(120→84) + Tanh        → (84)
+          → Linear(84→num_classes)        → (num_classes)
+    """
+
+    def __init__(
+        self, input_size: int = 32, in_channels: int = 1, num_classes: int = 10
+    ):
+        super().__init__(
+            input_size=input_size, in_channels=in_channels, num_classes=num_classes
+        )
+
+        # C1: Conv2d(1→6, 5×5, padding=0) — (N,1,32,32) → (N,6,28,28)
+        self.conv1 = nn.Conv2d(
+            in_channels=in_channels, out_channels=6, kernel_size=5, padding=0
+        )
+
+        # S2: AvgPool2d(2×2, stride=2) — (N,6,28,28) → (N,6,14,14)
+        self.pool1 = nn.AvgPool2d(kernel_size=2, stride=2)
+
+        # C3: Conv2d(6→16, 5×5, padding=0) — (N,6,14,14) → (N,16,10,10)
+        self.conv2 = nn.Conv2d(in_channels=6, out_channels=16, kernel_size=5, padding=0)
+
+        # S4: AvgPool2d(2×2, stride=2) — (N,16,10,10) → (N,16,5,5)
+        self.pool2 = nn.AvgPool2d(kernel_size=2, stride=2)
+
+        # C5: Conv2d(16→120, 5×5, padding=0) — (N,16,5,5) → (N,120,1,1)
+        self.conv3 = nn.Conv2d(
+            in_channels=16, out_channels=120, kernel_size=5, padding=0
+        )
+
+        # F6: Linear(120→84) + Tanh — (N,120) → (N,84)
+        self.fc1 = nn.Linear(in_features=120, out_features=84)
+
+        # Output: Linear(84→num_classes) — (N,84) → (N,num_classes)
+        self.fc2 = nn.Linear(in_features=84, out_features=num_classes)
+
+        self.tanh = nn.Tanh()
+
+        self._initWeights()
+
+    def _initWeights(self):
+        # Xavier 初始化
+        for m in self.modules():
+            if isinstance(m, (nn.Conv2d, nn.Linear)):
+                nn.init.xavier_uniform_(m.weight)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.tanh(self.conv1(x))  # C1
+        x = self.pool1(x)  # S2
+        x = self.tanh(self.conv2(x))  # C3
+        x = self.pool2(x)  # S4
+        x = self.tanh(self.conv3(x))  # C5
+        x = torch.flatten(x, 1)  # Flatten
+        x = self.tanh(self.fc1(x))  # F6
+        x = self.fc2(x)  # Output
+        return x

--- a/cnnlib/models/lenet.py
+++ b/cnnlib/models/lenet.py
@@ -5,11 +5,11 @@ Y. LeCun et al., "Gradient-Based Learning Applied to Document Recognition", 1998
 
 架构:
     Input (1, 32, 32)
-      → Conv2d(1→6, 5x5) + Tanh     → (6, 28, 28)
-      → AvgPool2d(2x2, stride=2)     → (6, 14, 14)
-      → Conv2d(6→16, 5x5) + Tanh    → (16, 10, 10)
-      → AvgPool2d(2x2, stride=2)     → (16, 5, 5)
-      → Conv2d(16→120, 5x5) + Tanh  → (120, 1, 1)
+      → Conv2d(1→6, 5×5) + Tanh     → (6, 28, 28)
+      → AvgPool2d(2×2, stride=2)     → (6, 14, 14)
+      → Conv2d(6→16, 5×5) + Tanh    → (16, 10, 10)
+      → AvgPool2d(2×2, stride=2)     → (16, 5, 5)
+      → Conv2d(16→120, 5×5) + Tanh  → (120, 1, 1)
       → Flatten                       → (120)
       → Linear(120→84) + Tanh        → (84)
       → Linear(84→num_classes)        → (num_classes)
@@ -36,11 +36,11 @@ class LeNet(BaseModel):
 
     架构:
         Input (1, 32, 32)
-          → Conv2d(1→6, 5x5) + Tanh     → (6, 28, 28)
-          → AvgPool2d(2x2, stride=2)     → (6, 14, 14)
-          → Conv2d(6→16, 5x5) + Tanh    → (16, 10, 10)
-          → AvgPool2d(2x2, stride=2)     → (16, 5, 5)
-          → Conv2d(16→120, 5x5) + Tanh  → (120, 1, 1)
+          → Conv2d(1→6, 5×5) + Tanh     → (6, 28, 28)
+          → AvgPool2d(2×2, stride=2)     → (6, 14, 14)
+          → Conv2d(6→16, 5×5) + Tanh    → (16, 10, 10)
+          → AvgPool2d(2×2, stride=2)     → (16, 5, 5)
+          → Conv2d(16→120, 5×5) + Tanh  → (120, 1, 1)
           → Flatten                       → (120)
           → Linear(120→84) + Tanh        → (84)
           → Linear(84→num_classes)        → (num_classes)
@@ -53,21 +53,21 @@ class LeNet(BaseModel):
             input_size=input_size, in_channels=in_channels, num_classes=num_classes
         )
 
-        # C1: Conv2d(1→6, 5x5, padding=0) — (N,1,32,32) → (N,6,28,28)
+        # C1: Conv2d(1→6, 5×5, padding=0) — (N,1,32,32) → (N,6,28,28)
         self.conv1 = nn.Conv2d(
             in_channels=in_channels, out_channels=6, kernel_size=5, padding=0
         )
 
-        # S2: AvgPool2d(2x2, stride=2) — (N,6,28,28) → (N,6,14,14)
+        # S2: AvgPool2d(2×2, stride=2) — (N,6,28,28) → (N,6,14,14)
         self.pool1 = nn.AvgPool2d(kernel_size=2, stride=2)
 
-        # C3: Conv2d(6→16, 5x5, padding=0) — (N,6,14,14) → (N,16,10,10)
+        # C3: Conv2d(6→16, 5×5, padding=0) — (N,6,14,14) → (N,16,10,10)
         self.conv2 = nn.Conv2d(in_channels=6, out_channels=16, kernel_size=5, padding=0)
 
-        # S4: AvgPool2d(2x2, stride=2) — (N,16,10,10) → (N,16,5,5)
+        # S4: AvgPool2d(2×2, stride=2) — (N,16,10,10) → (N,16,5,5)
         self.pool2 = nn.AvgPool2d(kernel_size=2, stride=2)
 
-        # C5: Conv2d(16→120, 5x5, padding=0) — (N,16,5,5) → (N,120,1,1)
+        # C5: Conv2d(16→120, 5×5, padding=0) — (N,16,5,5) → (N,120,1,1)
         self.conv3 = nn.Conv2d(
             in_channels=16, out_channels=120, kernel_size=5, padding=0
         )


### PR DESCRIPTION
- 新增 lenet.py，按原始论文实现 LeNet-5 架构（Tanh 激活、AvgPool、Xavier 初始化），通过 @register_model 注册
- 更新 init.py，将 conv_block/linear_block/inception_block/nin_block 及 LeNet 统一导出至 cnnlib.models 公共接口
- 统一 blocks.py 注释标点为半角符号（全角括号/乘号改为圆括号/x），与代码风格保持一致

close #28 